### PR TITLE
Fix packaging errors with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ build:
 	go build -o bin/gopsuinfo gopsuinfo.go
 
 install:
-	mkdir -p "${DESTDIR}/usr/share/gopsuinfo"
+	mkdir -p "${DESTDIR}/usr/share/gopsuinfo" "${DESTDIR}/usr/bin"
 	cp -R icons_light "${DESTDIR}/usr/share/gopsuinfo"
 	cp -R icons_dark "${DESTDIR}/usr/share/gopsuinfo"
-	cp bin/gopsuinfo "${DESTDIR}/usr/bin"
+	cp bin/gopsuinfo "${DESTDIR}/usr/bin/"
 
 uninstall:
 	rm -r "${DESTDIR}/usr/share/gopsuinfo"


### PR DESCRIPTION
`/usr/bin` may not exist so we need to create it

`cp bin/gopsuinfo "${DESTDIR}/usr/bin"` will copy gopsuinfo to `/usr/bin` *(as a file, not into the dir)*, the trailing slash should fix this.