### PR TITLE
Added `-ts` argument to specify which (t)emperature (s)sensor to show the value for. Closes #8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Add all the components you need to this way. Sample output with monochrome icons
 ![image](https://user-images.githubusercontent.com/20579136/171515322-f469d580-72e7-4950-9857-28746e380d6a.png)
 
 ```
-$ gopsuinfo -h
+❯ gopsuinfo -h
 Use gopsuinfo list_mountpoints to see available mount points.
-Usage of bin/gopsuinfo:
+Usage of gopsuinfo:
   -c string
     	Output (c)omponents: (a)vg CPU load, (g)rahical CPU bar,
     			disk usage by mou(n)tpoints, (t)emperatures,
@@ -41,9 +41,13 @@ Usage of bin/gopsuinfo:
     	use (dark) icon set
   -i string
     	returns (i)con path and a single component (a, n, t, m, u) value
+  -ls
+    	(l)ist temperature (s)ensors
   -p string
     	quotation-delimited, space-separated list of mount(p)oints (default "/")
   -t	Just (t)ext, no glyphs
+  -ts string
+    	show temperature for a certain (t)emperature (s)ensor (-ls to list available sensors)
   -v	display (v)ersion information
 ```
 

--- a/gopsuinfo.go
+++ b/gopsuinfo.go
@@ -24,7 +24,7 @@ import (
 	"github.com/shirou/gopsutil/net"
 )
 
-const version = "0.1.8"
+const version = "0.1.9"
 
 var g glyphs
 var path string

--- a/gopsuinfo.go
+++ b/gopsuinfo.go
@@ -236,8 +236,8 @@ func main() {
 	setPtr := flag.Bool("dark", false, "use (dark) icon set")
 	textPtr := flag.Bool("t", false, "Just (t)ext, no glyphs")
 	displayVersion := flag.Bool("v", false, "display (v)ersion information")
-	listTempSensors := flag.Bool("ls", false, "list temperature (s)ensors")
-	tempSensor := flag.String("ts", "", "show temperature for a certain Temperature Sensor (-ls to list available sensors)")
+	listTempSensors := flag.Bool("ls", false, "(l)ist temperature (s)ensors")
+	tempSensor := flag.String("ts", "", "show temperature for a certain (t)emperature (s)ensor (-ls to list available sensors)")
 
 	flag.Parse()
 

--- a/gopsuinfo.go
+++ b/gopsuinfo.go
@@ -51,6 +51,14 @@ func cpuAvSpeed(asIcon bool, delay *string) string {
 	return output
 }
 
+func listSensors() {
+	temps, _ := host.SensorsTemperatures()
+	for _, temp := range temps {
+		fmt.Printf("%s %v\n", temp.SensorKey, temp.Temperature)
+	}
+	os.Exit(0)
+}
+
 func temperatures(asIcon bool) string {
 	output := ""
 	if !asIcon {
@@ -213,12 +221,17 @@ func main() {
 	setPtr := flag.Bool("dark", false, "use (dark) icon set")
 	textPtr := flag.Bool("t", false, "Just (t)ext, no glyphs")
 	displayVersion := flag.Bool("v", false, "display (v)ersion information")
+	listTempSensors := flag.Bool("s", false, "list temperature (s)ensors")
 
 	flag.Parse()
 
 	if *displayVersion {
 		fmt.Printf("gopsuinfo version %s\n", version)
 		os.Exit(0)
+	}
+
+	if *listTempSensors {
+		listSensors()
 	}
 
 	if *textPtr {

--- a/gopsuinfo.go
+++ b/gopsuinfo.go
@@ -70,6 +70,7 @@ func temperatures(asIcon bool, tempSensor string) string {
 
 	temps, _ := host.SensorsTemperatures()
 
+	// temp sensor name given with the -ts flag
 	if tempSensor != "" {
 		for _, temp := range temps {
 			if temp.SensorKey == tempSensor {
@@ -79,6 +80,7 @@ func temperatures(asIcon bool, tempSensor string) string {
 		return fmt.Sprintf("No such sensor as '%s', try the -ls flag", tempSensor)
 	}
 
+	// temp sensor name not given
 	for _, temp := range temps {
 		// Some machines may return multiple sensors of the same name. Let's accept the 1st non-zero temp value.
 		if vals["acpitz"] == 0 && temp.SensorKey == "acpitz_input" {

--- a/gopsuinfo.go
+++ b/gopsuinfo.go
@@ -61,7 +61,7 @@ func listSensors() {
 	os.Exit(0)
 }
 
-func temperatures(asIcon bool, tempSensor string) string {
+func temperatures(asIcon bool, sensorName string) string {
 	output := ""
 	if !asIcon {
 		output += g.glyphTemp
@@ -71,13 +71,14 @@ func temperatures(asIcon bool, tempSensor string) string {
 	temps, _ := host.SensorsTemperatures()
 
 	// temp sensor name given with the -ts flag
-	if tempSensor != "" {
+	sensorName = strings.TrimSpace(sensorName)
+	if sensorName != "" {
 		for _, temp := range temps {
-			if temp.SensorKey == tempSensor {
+			if temp.SensorKey == sensorName {
 				return fmt.Sprintf("%v℃", int(math.Round(temp.Temperature)))
 			}
 		}
-		return fmt.Sprintf("No such sensor as '%s', try the -ls flag", tempSensor)
+		return fmt.Sprintf("No such sensor as '%s', try the -ls flag", sensorName)
 	}
 
 	// temp sensor name not given


### PR DESCRIPTION
1. List available sensors with the `-ls` argument:

```text
❯ gopsuinfo -ls
acpitz_input (43°C)
amdgpu_edge_input (45°C)
amdgpu_junction_input (47°C)
amdgpu_mem_input (0°C)
amdgpu_edge_input (41°C)
nvme_composite_input (40.85°C)
nvme_sensor1_input (40.85°C)
nvme_sensor2_input (39.85°C)
k10temp_tctl_input (41.125°C)
```

2. Use one as the `-ts` string, e.g. to show the temperature value for the `k10temp_tctl_input` sensor:

```text
❯ gopsuinfo -c t -ts k10temp_tctl_input
47℃
```